### PR TITLE
Solved some edge cases

### DIFF
--- a/src/ineqpy/inequality.py
+++ b/src/ineqpy/inequality.py
@@ -80,6 +80,10 @@ def concentration(income, weights=None, data=None, sort=True):
     elif weights.ndim == 2:
         weights = np.squeeze(weights, axis=1)
 
+    # Small shortcut to avoid warnings below
+    if income.size <= 1:
+        return np.nan
+
     # if sort is true then sort the variables.
     if sort:
         income, weights = utils._sort_values(income, weights)
@@ -508,6 +512,10 @@ def top_rest(income, weights=None, data=None, top_percentage=10.0):
     else:
         income = income.copy()
         weights = np.ones_like(income) if weights is None else weights.copy()
+
+    # Small shortcut to avoid divide by zero below
+    if income.size <= 1:
+        return np.nan
 
     income, weights = utils._sort_values(income, weights)
 

--- a/src/ineqpy/inequality.py
+++ b/src/ineqpy/inequality.py
@@ -69,18 +69,23 @@ def concentration(income, weights=None, data=None, sort=True):
     income, weights = utils.extract_values(data, income, weights)
     if weights is None:
         weights = utils.not_empty_weights(weights, like=income)
+
+    if income.ndim == 0:
+        income = np.array([income])
+    elif income.ndim == 2:
+        income = np.squeeze(income, axis=1)
+
+    if weights.ndim == 0:
+        weights = np.array([weights])
+    elif weights.ndim == 2:
+        weights = np.squeeze(weights, axis=1)
+
     # if sort is true then sort the variables.
     if sort:
         income, weights = utils._sort_values(income, weights)
 
-    if weights.ndim == 2:
-        weights = np.squeeze(weights, axis=1)
-
-    if income.ndim == 2:
-        income = np.squeeze(income, axis=1)
-
     # main calc
-    f_x = utils.normalize(weights)
+    f_x = np.atleast_1d(utils.normalize(weights))
     F_x = f_x.cumsum(axis=0)
     mu = np.sum(income * f_x)
     cov = np.cov(income, F_x, rowvar=False, aweights=f_x)[0, 1]
@@ -122,6 +127,8 @@ def lorenz(income, weights=None, data=None):
     """
     if data is not None:
         income, weights = utils.extract_values(data, income, weights)
+    if weights is None:
+        weights = utils.not_empty_weights(weights, like=income)
 
     total_income = income * weights
     idx_sort = np.argsort(income)
@@ -262,7 +269,7 @@ def atkinson(income, weights=None, data=None, e=0.5) -> float:
 
     # auxiliar variables: mean and distribution
     mu = mean(variable=income, weights=weights)
-    f_i = weights / sum(weights)  # density function
+    f_i = np.atleast_1d(weights / sum(weights))  # density function
 
     # main calc
     if e == 1:
@@ -396,7 +403,11 @@ def theil(income, weights=None, data=None):
         income, weights = utils.extract_values(data, income, weights)
     else:
         income = income.copy()
-        weights = weights.copy()
+
+        if weights is None:
+            weights = utils.not_empty_weights(weights, like=income)
+        else:
+            weights = weights.copy()
     income, weights = utils.not_null_condition(income, weights)
 
     # variables needed
@@ -505,7 +516,7 @@ def top_rest(income, weights=None, data=None, top_percentage=10.0):
     cumw = np.cumsum(weights)
     ftosearch = 1 - top_percentage / 100
     k = np.searchsorted(cumw, ftosearch, side='right')
-    f_i = income*weights
+    f_i = np.atleast_1d(income*weights)
 
     t = np.sum(f_i[k:])
     r = np.sum(f_i[:k])
@@ -556,7 +567,10 @@ def hoover(income, weights=None, data=None):
         income, weights = utils.extract_values(data, income, weights)
     else:
         income = income.copy()
-        weights = weights.copy()
+        if weights is None:
+            weights = utils.not_empty_weights(weights, like=income)
+        else:
+            weights = weights.copy()
 
     income, weights = utils.not_null_condition(income, weights)
 

--- a/tests/test_inequality.py
+++ b/tests/test_inequality.py
@@ -74,6 +74,22 @@ def test_atkinson_1d_1_w():
     expected = 0
     assert obtained==expected
 
+def test_theil_1d_series():
+    """ Testing theil with no weights. Every value is the same """
+    x = np.repeat(5, 10)
+    
+    obtained = inequality.theil(income=x)
+    expected = 0
+
+    np.testing.assert_almost_equal(obtained, expected)
+
+def test_theil_1d_series_2():
+    x = np.arange(1, 10)
+
+    obtained = inequality.theil(income=x)
+    expected = 0.1473838569435545
+
+    np.testing.assert_almost_equal(obtained, expected)
 
 def test_theil_1d_1_w():
     # TODO check this
@@ -141,6 +157,14 @@ def test_ratio_unweighted():
     expected = 0.22203712517848642
     assert pytest.approx(obtained) == expected
 
+
+def test_hoover_index_series():
+    """ Testing hoover with no weights (default all ones) """
+    x = np.arange(10)
+    obtained = inequality.hoover(x)
+    expected = 4.0
+
+    np.testing.assert_almost_equal(obtained, expected)
 
 def test_hoover_index():
     x = np.arange(10)

--- a/tests/test_inequality.py
+++ b/tests/test_inequality.py
@@ -1,7 +1,15 @@
+from unittest import expectedFailure
 import numpy as np
 from ineqpy import inequality
 import pytest
 
+
+def test_concentration_0d():
+    x = np.array([100])
+
+    obtained = inequality.concentration(income=x)
+
+    assert np.isnan(obtained)
 
 def test_gini_2d():
     x = np.array([[57], [63], [81], [79], [88], [57], [42], [3], [77], [89]])
@@ -99,7 +107,7 @@ def test_theil_1d_1_w():
     expected = 0
     assert obtained==expected
 
-def test_ratio_eqaulity():
+def test_ratio_equality():
     x = np.array([1, 9])
     w = np.array([9, 1])
     obtained = inequality.top_rest(income=x, weights=w)
@@ -110,6 +118,12 @@ def test_ratio_equality_fracc():
     w = np.array([.9, .1])
     obtained = inequality.top_rest(income=x, weights=w)
     assert obtained == 1.0
+
+def test_ratio_0d():
+    x = np.array([100])
+    obtained = inequality.top_rest(income=x)
+
+    assert np.isnan(obtained)
 
 def test_ratio_1d():
     x = np.array([57, 63, 81, 79, 88, 42, 3, 77, 89])


### PR DESCRIPTION
When I tried to apply these functions to a groupby, it raised a lot of errors, mainly when the dataset had 1 or 2 items (and no weights). It should return anything instead of an error, even if it is np.nan.

- Weights can be null on more methods.
- Solved problems when applying to arrays with one element.